### PR TITLE
bugfix: remove warning message when running tests

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.test.json',
+      tsconfig: 'tsconfig.test.json',
     },
   },
 };

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,6 +1,5 @@
 require('@testing-library/jest-dom');
 
-// eslint-disable-next-line no-undef
 jest.mock('next-i18next', () => ({
   useTranslation: () => {
     return {
@@ -8,3 +7,12 @@ jest.mock('next-i18next', () => ({
     };
   },
 }));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => {
+    return {
+      t: key => key,
+    };
+  },
+}));
+

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -15,4 +15,3 @@ jest.mock('react-i18next', () => ({
     };
   },
 }));
-


### PR DESCRIPTION
### Description

Renamed the tsconfig property in the jest config file to remove the warning when running tests

### Scout rule, helpful cleanups

Mocked instance of of react-i18next ine the jest-setup file to remove the warning saying we should mock it.

### What was tested

Ran test before change with alot of warning, no warning when running test after change

### Issues

Closes #42

### General PR check list

- [ ] Add tests for new domain logic
- [ ] Update documentation (`README.md` + `/docs`)
- [ ] Make sure PR author is listed in contributors
- [ ] Keep PRs small, otherwise split into chunks
- [ ] {add any check list item specific to your PR}

### Results
Before
![image](https://user-images.githubusercontent.com/113033390/189998143-aaed7e0e-5bbd-40b7-bc0c-7c89d040ae4f.png)

After
![image](https://user-images.githubusercontent.com/113033390/189998044-6b01ca30-097f-4752-83f4-b0fa202c5762.png)

